### PR TITLE
Convert HTML entities (e.g. `&nbsp;`) that are invalid in XML into numeric character references (e.g. `&#160;`) to avoid parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 =========
 [Top](./README.md) / English / [Japanese](./CHANGELOG_ja.md)
 
+- Convert HTML entities (e.g. `&nbsp;`) that are invalid in XML into numeric character references (e.g. `&#160;`) to avoid parsing errors. (#6, #7, thanks to @vincentwskuo)
+
 v0.5.0
 ------
 Mar 3, 2025

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,8 @@ Changelog
 =========
 [Top](./README.md) / [English](./CHANGELOG.md) / Japanese
 
+- `&nbsp;` など、XMLでは未定義のHTMLエンティティがエラーにならないよう、`&#160;` のような数値参照に変換して扱うようにした。 (#6, #7, thanks to @vincentwskuo)
+
 v0.5.0
 ------
 Mar 3, 2025

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,14 @@ VERSION=$(shell git describe --tags 2>$(NUL) || echo v0.0.0)
 GOOPT=-ldflags "-s -w -X main.version=$(VERSION)"
 EXT=$(shell go env GOEXE)
 
-all:
+debug:
 	go fmt ./...
-	$(SET) "CGO_ENABLED=0" && go build $(GOOPT)
-	$(foreach I,$(wildcard cmd/*),$(SET) "CGO_ENABLED=0" && go build -C $(I) -o $(CURDIR) $(GOOPT) && ) echo OK
+	$(SET) "CGO_ENABLED=0" && go build $(GOOPT) -tags debug ./cmd/unenex
+	$(SET) "CGO_ENABLED=0" && go build $(GOOPT) -tags debug ./cmd/exstyle
 
 _dist:
-	$(MAKE) all
+	$(SET) "CGO_ENABLED=0" && go build $(GOOPT) ./cmd/unenex
+	$(SET) "CGO_ENABLED=0" && go build $(GOOPT) ./cmd/exstyle
 	zip $(NAME)-$(VERSION)-$(GOOS)-$(GOARCH).zip unenex$(EXT) exstyle$(EXT)
 
 dist:

--- a/README.md
+++ b/README.md
@@ -123,13 +123,10 @@ Changelog
 Acknowledgements
 ---------------
 
-- [Laetgark](https://github.com/Laetgark) - [#1]
-- [Juelicher-Trainee](https://github.com/Juelicher-Trainee) - [#2]
-- [mikaeloduh (Michael D)](https://github.com/mikaeloduh) - [#3]
-
-[#1]: https://github.com/hymkor/go-enex/issues/1
-[#2]: https://github.com/hymkor/go-enex/issues/2
-[#3]: https://github.com/hymkor/go-enex/pull/3
+- [Laetgark](https://github.com/Laetgark)
+- [Juelicher-Trainee](https://github.com/Juelicher-Trainee)
+- [mikaeloduh (Michael D)](https://github.com/mikaeloduh)
+- [vincentwskuo](https://github.com/vincentwskuo)
 
 Author
 ------

--- a/bundle.go
+++ b/bundle.go
@@ -59,7 +59,7 @@ func (B *Bundle) Extract(rootDir string, log io.Writer) error {
 		}
 		data, err := data.Data()
 		if err != nil {
-			return err
+			return stackTrace(err, "(*Bundle) Extract")
 		}
 		if err := os.WriteFile(fname, data, 0644); err != nil {
 			return err

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,23 @@
+//go:build debug
+
+package enex
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nyaosorg/go-windows-dbg"
+)
+
+const debugBuild = true
+
+func debug(v ...any) {
+	dbg.Println(v...)
+}
+
+func stackTrace(e error, s ...string) error {
+	if e == nil {
+		return nil
+	}
+	return fmt.Errorf("%w\nat %s", e, strings.Join(s, " "))
+}

--- a/extract.go
+++ b/extract.go
@@ -1,7 +1,6 @@
 package enex
 
 import (
-	"encoding/xml"
 	"fmt"
 	"path"
 	"regexp"
@@ -124,7 +123,7 @@ func (note *Note) extract(makeRscUrl func(*Resource) string, opt *Option) string
 
 	// Parse the content as XML to extract just the inner content
 	var enNote xmlEnNote
-	if err := xml.Unmarshal([]byte(content), &enNote); err == nil {
+	if err := xmlUnmarshal([]byte(content), &enNote); err == nil {
 		content = enNote.Text
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/hymkor/go-enex
 
 go 1.18
 
-require github.com/mattn/godown v0.0.1
+require (
+	github.com/mattn/godown v0.0.1
+	github.com/nyaosorg/go-windows-dbg v0.0.0-20240724174901-9645d9b1df23
+)
 
 require (
 	github.com/mattn/go-runewidth v0.0.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuuj
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/godown v0.0.1 h1:39uk50ufLVQFs0eapIJVX5fCS74a1Fs2g5f1MVqIHdE=
 github.com/mattn/godown v0.0.1/go.mod h1:/ivCKurgV/bx6yqtP/Jtc2Xmrv3beCYBvlfAUl4X5g4=
+github.com/nyaosorg/go-windows-dbg v0.0.0-20240724174901-9645d9b1df23 h1:PsACS2RhmWIsc39eiIQ4EeEww+OFT0gn60TG0MFObrg=
+github.com/nyaosorg/go-windows-dbg v0.0.0-20240724174901-9645d9b1df23/go.mod h1:2KBQW9Jv7m6jB8WDgvZOVsJXwtbk4MRIpOWt/n/EDwg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/ndebug.go
+++ b/ndebug.go
@@ -1,0 +1,11 @@
+//go:build !debug
+
+package enex
+
+const debugBuild = false
+
+func debug(v ...any) {}
+
+func stackTrace(e error, _ ...string) error {
+	return e
+}

--- a/parser.go
+++ b/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-
 	"strings"
 )
 
@@ -80,7 +79,7 @@ type Note struct {
 // Logs are written to the provided warn writer.
 func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 	var theXml xmlEnExport
-	err := xml.Unmarshal(data, &theXml)
+	err := xmlUnmarshal(data, &theXml)
 	if err != nil {
 		return nil, stackTrace(err, "Parse: xml.Unmarshal", string(data))
 	}
@@ -100,7 +99,7 @@ func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 			if len(rsc.Recognition) > 0 {
 				var recoIndex xmlRecoIndex
 
-				err = xml.Unmarshal(rsc.Recognition, &recoIndex)
+				err = xmlUnmarshal(rsc.Recognition, &recoIndex)
 				if err == nil && recoIndex.ObjID != "" {
 					fmt.Fprintln(warn, "objID:", recoIndex.ObjID)
 					r.Hash = recoIndex.ObjID
@@ -125,7 +124,7 @@ func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 			resource[rsc.FileName] = append(resource[rsc.FileName], r)
 		}
 		var enNote xmlEnNote
-		if err := xml.Unmarshal(note.Content, &enNote); err != nil {
+		if err := xmlUnmarshal(note.Content, &enNote); err != nil {
 			return nil, stackTrace(err, "Parse: xml.Unmarshal:", string(note.Content))
 		}
 		notes = append(notes, &Note{

--- a/parser.go
+++ b/parser.go
@@ -82,7 +82,7 @@ func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 	var theXml xmlEnExport
 	err := xml.Unmarshal(data, &theXml)
 	if err != nil {
-		return nil, err
+		return nil, stackTrace(err, "Parse: xml.Unmarshal", string(data))
 	}
 	notes := make([]*Note, 0, len(theXml.Note))
 	for _, note := range theXml.Note {
@@ -126,7 +126,7 @@ func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 		}
 		var enNote xmlEnNote
 		if err := xml.Unmarshal(note.Content, &enNote); err != nil {
-			return nil, err
+			return nil, stackTrace(err, "Parse: xml.Unmarshal:", string(note.Content))
 		}
 		notes = append(notes, &Note{
 			Title:    note.Title,

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,48 @@
+package enex
+
+import (
+	"bytes"
+	"encoding/xml"
+	"html"
+	"regexp"
+	"strconv"
+	"unicode/utf8"
+)
+
+var entityTables = [][2][]byte{
+	[2][]byte{[]byte("&lt;"), []byte("\uE001")},
+	[2][]byte{[]byte("&gt;"), []byte("\uE002")},
+	[2][]byte{[]byte("&amp;"), []byte("\uE003")},
+	[2][]byte{[]byte("&quot;"), []byte("\uE004")},
+	[2][]byte{[]byte("&apos;"), []byte("\uE005")},
+}
+
+var reEntity = regexp.MustCompile(`&[a-zA-z][a-zA-Z0-9]*;`)
+
+func xmlUnmarshal(data []byte, v any) error {
+	for _, v := range entityTables {
+		data = bytes.ReplaceAll(data, v[0], v[1])
+	}
+	data = reEntity.ReplaceAllFunc(data, func(srcBin []byte) []byte {
+		srcStr := string(srcBin)
+		decoded := html.UnescapeString(srcStr)
+		if decoded == srcStr || decoded == "" {
+			return srcBin
+		}
+		r, siz := utf8.DecodeRuneInString(decoded)
+		if r == utf8.RuneError || len(decoded) > siz {
+			debug("failed:", srcStr)
+			return srcBin
+		}
+		bin := make([]byte, 0, 10)
+		bin = append(bin, '&', '#')
+		bin = strconv.AppendInt(bin, int64(r), 10)
+		bin = append(bin, ';')
+		debug(srcStr, "->", string(bin))
+		return bin
+	})
+	for _, v := range entityTables {
+		data = bytes.ReplaceAll(data, v[1], v[0])
+	}
+	return stackTrace(xml.Unmarshal(data, v), "xmlUnmarshal")
+}

--- a/unenex-html.go
+++ b/unenex-html.go
@@ -22,7 +22,7 @@ const indexHtmlFooter = "</body></html>"
 func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, webClipOnly bool, wDebug, wLog io.Writer) error {
 	exports, err := Parse(source, wDebug)
 	if err != nil {
-		return err
+		return stackTrace(err, "ToHtmls")
 	}
 	err = makeDir(rootDir, enexName, wLog)
 	if err != nil {
@@ -65,7 +65,7 @@ func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, webClip
 		fmt.Fprintln(wLog, "Create File:", fname)
 
 		if err := bundle.Extract(rootDir, wLog); err != nil {
-			return err
+			return stackTrace(err, "ToHtmls")
 		}
 	}
 	return nil
@@ -95,7 +95,7 @@ func FilesToHtmls(rootDir, styleSheet string, enexFiles []string, webClipOnly bo
 		}
 		enexName := getEnexBaseName(enexFileName)
 		if err := ToHtmls(rootDir, enexName, data, styleSheet, webClipOnly, wDebug, wLog); err != nil {
-			return err
+			return stackTrace(err, "FilesToHtmls")
 		}
 		fmt.Fprintf(wIndex, "<li><a href=\"%s/index.html\">%s</a></li>\n",
 			url.PathEscape(enexName), enexName)


### PR DESCRIPTION
- Convert HTML entities (e.g. `&nbsp;`) that are invalid in XML into numeric character references (e.g. `&#160;`) to avoid parsing errors. (#6)
&nbsp;
- `&nbsp;` など、XMLでは未定義のHTMLエンティティがエラーにならないよう、`&#160;` のような数値参照に変換して扱うようにした。 (#6)
