### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 =========
 [Top](./README.md) / English / [Japanese](./CHANGELOG_ja.md)
 
+v0.5.1
+------
+Apr 18, 2026
+
 - Convert HTML entities (e.g. `&nbsp;`) that are invalid in XML into numeric character references (e.g. `&#160;`) to avoid parsing errors. (#6, #7, thanks to @vincentwskuo)
 
 v0.5.0

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,10 @@ Changelog
 =========
 [Top](./README.md) / [English](./CHANGELOG.md) / Japanese
 
+v0.5.1
+------
+Apr 18, 2026
+
 - `&nbsp;` など、XMLでは未定義のHTMLエンティティがエラーにならないよう、`&#160;` のような数値参照に変換して扱うようにした。 (#6, #7, thanks to @vincentwskuo)
 
 v0.5.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 zetamatta
+Copyright (c) 2021-2026 HAYAMA_Kaoru (a.k.a zetamatta)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ dist:
 	$(SET) "GOOS=windows" && $(SET) "GOARCH=amd64" && $(MAKE) _dist
 
 release:
-	gh release create -d --notes "" -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
+	go run github.com/hymkor/latest-notes@latest | gh release create -d --notes-file - -t $(VERSION) $(VERSION) $(wildcard $(NAME)-$(VERSION)-*.zip)
 
 manifest:
-	make-scoop-manifest *-windows-*.zip > $(NAME).json
+	go run github.com/hymkor/make-scoop-manifest@latest -all *-windows-*.zip > $(NAME).json
 
 clean:
 	$(RM) *.png *.html

--- a/unenex.json
+++ b/unenex.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "(unenex) Convert Evernote's export file(*.enex) into HTML and images",
     "homepage": "https://github.com/hymkor/go-enex",
     "license": "MIT License",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.0/unenex-v0.5.0-windows-386.zip",
-            "hash": "f43db26987a9a77e66f70edb4bb015809da1a11d8e78aff60841ce9e31316914"
+            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.1/unenex-v0.5.1-windows-386.zip",
+            "hash": "6ab9527d6419b79d9dc4fd9c6d21d7faf38d12f388d600ce588e164d5937bb63"
         },
         "64bit": {
-            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.0/unenex-v0.5.0-windows-amd64.zip",
-            "hash": "fe1eb8e014a858441e51cd29d421c0459458c1dbb6825f65832d2589170c7cf5"
+            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.1/unenex-v0.5.1-windows-amd64.zip",
+            "hash": "3028ce47d1e2079e8e643b359cbae4f555d1c2d240c6f4ed99cb3367046b14ee"
         }
     },
     "bin": [


### PR DESCRIPTION
- [Release v0.5.1 · hymkor/go-enex](https://github.com/hymkor/go-enex/releases/tag/v0.5.1)
 
- [Convert HTML entities (e.g. `&nbsp;`) that are invalid in XML into numeric character references (e.g. `&#160;`) to avoid parsing errors by hymkor · Pull Request #7 · hymkor/go-enex](https://github.com/hymkor/go-enex/pull/7)

- [Program stops with error "XML syntax error on line 7: invalid character entity &nbsp;" · Issue #6 · hymkor/go-enex](https://github.com/hymkor/go-enex/issues/6)