### PR TITLE
Add fallback to match resources by width/height when en-media hash lookup fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 =========
 [Top](./README.md) / English / [Japanese](./CHANGELOG_ja.md)
 
+- Add a fallback mechanism to resolve image resources when the `<en-media>` hash cannot be matched, by using the original image dimensions (`--en-naturalWidth` / `--en-naturalHeight`) found in the `style` attribute (instead of the `width` / `height` display attributes). (#5, #9, thanks to @fangbb-coder)
+
 v0.5.1
 ------
 Apr 18, 2026

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,8 @@ Changelog
 =========
 [Top](./README.md) / [English](./CHANGELOG.md) / Japanese
 
+- `<en-media>` の hash 属性で画像リソースを特定できない場合、style 属性に含まれる元画像のサイズ（`--en-naturalWidth` / `--en-naturalHeight`）を用いて一致するリソースを検索するフォールバック機構を追加した（表示用の `width` / `height` 属性ではなく元サイズを使用） (#5, #9, thanks to @fangbb-coder)
+
 v0.5.1
 ------
 Apr 18, 2026

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Acknowledgements
 - [Laetgark](https://github.com/Laetgark)
 - [Juelicher-Trainee](https://github.com/Juelicher-Trainee)
 - [mikaeloduh (Michael D)](https://github.com/mikaeloduh)
+- [fangbb-coder](https://github.com/fangbb-coder)
 - [vincentwskuo](https://github.com/vincentwskuo)
 
 Author

--- a/extract.go
+++ b/extract.go
@@ -2,6 +2,7 @@ package enex
 
 import (
 	"fmt"
+	"io"
 	"path"
 	"regexp"
 	"strings"
@@ -46,12 +47,12 @@ func parseEnMediaAttr(s string) map[string]string {
 				break
 			}
 			if strings.ContainsRune(" \v\t\r\n", c) {
-				result[name.String()] = ""
+				//result[name.String()] = ""
 				break
 			}
 			name.WriteRune(c)
 			if len(s) <= 0 {
-				result[name.String()] = ""
+				//result[name.String()] = ""
 				return result
 			}
 			c, siz = utf8.DecodeRuneInString(s)
@@ -103,6 +104,8 @@ type Option struct {
 	ExHeader    string
 	Sanitizer   func(string) string
 	WebClipOnly bool // If true, only output the web-clip content without Evernote styling
+	Log         io.Writer
+	NoFallback  bool
 }
 
 const (
@@ -130,17 +133,22 @@ func (note *Note) extract(makeRscUrl func(*Resource) string, opt *Option) string
 	// Remove empty br tags
 	content = rxEmptyBr.ReplaceAllString(content, "")
 
+	log := io.Discard
+	if opt != nil && opt.Log != nil {
+		log = opt.Log
+	}
+	noFallback := false
+	if opt != nil {
+		noFallback = opt.NoFallback
+	}
+
 	// Process any en-media tags in the content
 	content = enTagReplacer.Replace(content)
 	content = rxMedia.ReplaceAllStringFunc(content, func(tag string) string {
 		attr := parseEnMediaAttr(tag)
-		hash, ok := attr["hash"]
-		if !ok {
-			return `<!-- Error: hash not found -->`
-		}
-		rsc, ok := note.Hash[hash]
-		if !ok {
-			return fmt.Sprintf(`<!-- Error: hash="%s" -->`, hash)
+		rsc, notfound := note.Lookup(attr, noFallback, log)
+		if notfound != "" {
+			return notfound
 		}
 		rscUrl := makeRscUrl(rsc)
 		typ, _, ok := strings.Cut(rsc.Mime, "/")

--- a/lookup.go
+++ b/lookup.go
@@ -1,0 +1,86 @@
+package enex
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+func dumpAttr(attr map[string]string, w io.Writer) {
+	for key, val := range attr {
+		fmt.Fprintf(w, "%q=%q\n", key, val)
+	}
+}
+
+var (
+	rxStyleWidth  = regexp.MustCompile(`--en-naturalWidth:(\d+)`)
+	rxStyleHeight = regexp.MustCompile(`--en-naturalHeight:(\d+)`)
+)
+
+func (note *Note) LookupWithStyle(style string, log io.Writer) *Resource {
+	w, h := -1, -1
+	if s := rxStyleWidth.FindStringSubmatch(style); s != nil {
+		if v, err := strconv.Atoi(s[1]); err == nil {
+			w = v
+		}
+	}
+	if s := rxStyleHeight.FindStringSubmatch(style); s != nil {
+		if v, err := strconv.Atoi(s[1]); err == nil {
+			h = v
+		}
+	}
+	var lastFound *Resource
+	defer func() {
+		if lastFound != nil {
+			fmt.Fprintf(log, "Falling back to dimension-based matching (width=%d, height=%d).\n", w, h)
+		}
+	}()
+	for _, resouces := range note.Resource {
+		for _, r := range resouces {
+			if r.Width == w && r.Height == h {
+				if !r.touch {
+					lastFound = r
+					r.touch = true
+					return r
+				}
+				lastFound = r
+			}
+		}
+	}
+	return lastFound
+}
+
+func (note *Note) LookupWithHash(hash string, log io.Writer) *Resource {
+	rsc, ok := note.Hash[hash]
+	if !ok {
+		fmt.Fprintf(log, "No resource matched the hash (%q).\n", hash)
+		return nil
+	}
+	return rsc
+}
+
+func (note *Note) Lookup(
+	attr map[string]string,
+	noFallback bool,
+	log io.Writer) (*Resource, string) {
+
+	var reason string
+	if hash, ok := attr["hash"]; ok {
+		if rsc := note.LookupWithHash(hash, log); rsc != nil {
+			return rsc, ""
+		}
+		reason = fmt.Sprintf(`<!-- Error: No resource matched the hash (%q). -->`, hash)
+	} else {
+		reason = `<!-- Error: no hash specified in en-media -->`
+		fmt.Fprintln(log, "No hash specified in en-media.")
+	}
+	if !noFallback {
+		if style, ok := attr["style"]; ok {
+			if r := note.LookupWithStyle(style, log); r != nil {
+				return r, ""
+			}
+		}
+	}
+	return nil, reason
+}

--- a/parser.go
+++ b/parser.go
@@ -53,6 +53,7 @@ type Resource struct {
 	Width       int
 	Height      int
 	NewFileName string
+	touch       bool
 }
 
 // WriteTo writes the attachment data from rsc to w.
@@ -96,6 +97,10 @@ func Parse(data []byte, warn io.Writer) ([]*Note, error) {
 				Height:   rsc.Height,
 			}
 			fmt.Fprintln(warn, "Filename:", rsc.FileName)
+			fmt.Fprintln(warn, "SourceUrl:", rsc.SourceUrl)
+			fmt.Fprintln(warn, "Width:", rsc.Width)
+			fmt.Fprintln(warn, "Height:", rsc.Height)
+			fmt.Fprintln(warn, "Mime:", rsc.Mime)
 			if len(rsc.Recognition) > 0 {
 				var recoIndex xmlRecoIndex
 

--- a/unenex-html.go
+++ b/unenex-html.go
@@ -48,6 +48,7 @@ func ToHtmls(rootDir, enexName string, source []byte, styleSheet string, webClip
 	opt := &Option{
 		ExHeader:    styleSheet,
 		WebClipOnly: webClipOnly,
+		Log:         wLog,
 	}
 
 	for _, note := range exports {

--- a/unenex-markdown.go
+++ b/unenex-markdown.go
@@ -34,8 +34,12 @@ func ToMarkdowns(rootDir, enexName string, source []byte, htmlToMarkdown func(io
 		fmt.Fprintf(index, "# %s\n\n", enexName)
 	}
 
+	opt := &Option{
+		Log: wLog,
+	}
+
 	for _, note := range exports {
-		html, bundle := note.Extract(nil)
+		html, bundle := note.Extract(opt)
 		safeName := bundle.BaseName
 
 		fmt.Fprintf(index, "* [%s](%s)\n",


### PR DESCRIPTION
- Add a fallback mechanism to resolve image resources when the `<en-media>` hash cannot be matched, by using the original image dimensions (`--en-naturalWidth` / `--en-naturalHeight`) found in the `style` attribute (instead of the `width` / `height` display attributes). (#5 )
&nbsp;
- `<en-media>` の hash 属性で画像リソースを特定できない場合、style 属性に含まれる元画像のサイズ（`--en-naturalWidth` / `--en-naturalHeight`）を用いて一致するリソースを検索するフォールバック機構を追加した（表示用の `width` / `height` 属性ではなく元サイズを使用） (#5 )
