### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog
 =========
 [Top](./README.md) / English / [Japanese](./CHANGELOG_ja.md)
 
+v0.6.0
+------
+Apr 18, 2026
+
 - Add a fallback mechanism to resolve image resources when the `<en-media>` hash cannot be matched, by using the original image dimensions (`--en-naturalWidth` / `--en-naturalHeight`) found in the `style` attribute (instead of the `width` / `height` display attributes). (#5, #9, thanks to @fangbb-coder)
 
 v0.5.1

--- a/CHANGELOG_ja.md
+++ b/CHANGELOG_ja.md
@@ -2,6 +2,10 @@ Changelog
 =========
 [Top](./README.md) / [English](./CHANGELOG.md) / Japanese
 
+v0.6.0
+------
+Apr 18, 2026
+
 - `<en-media>` の hash 属性で画像リソースを特定できない場合、style 属性に含まれる元画像のサイズ（`--en-naturalWidth` / `--en-naturalHeight`）を用いて一致するリソースを検索するフォールバック機構を追加した（表示用の `width` / `height` 属性ではなく元サイズを使用） (#5, #9, thanks to @fangbb-coder)
 
 v0.5.1

--- a/unenex.json
+++ b/unenex.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "(unenex) Convert Evernote's export file(*.enex) into HTML and images",
     "homepage": "https://github.com/hymkor/go-enex",
     "license": "MIT License",
     "architecture": {
         "32bit": {
-            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.1/unenex-v0.5.1-windows-386.zip",
-            "hash": "6ab9527d6419b79d9dc4fd9c6d21d7faf38d12f388d600ce588e164d5937bb63"
+            "url": "https://github.com/hymkor/go-enex/releases/download/v0.6.0/unenex-v0.6.0-windows-386.zip",
+            "hash": "e43e88a76880a6e2b2e39d5db39a79d32c3cffbdb4c1f491960c30abd479515d"
         },
         "64bit": {
-            "url": "https://github.com/hymkor/go-enex/releases/download/v0.5.1/unenex-v0.5.1-windows-amd64.zip",
-            "hash": "3028ce47d1e2079e8e643b359cbae4f555d1c2d240c6f4ed99cb3367046b14ee"
+            "url": "https://github.com/hymkor/go-enex/releases/download/v0.6.0/unenex-v0.6.0-windows-amd64.zip",
+            "hash": "030cfac05a25170d210cf327f76936e7d0e69458dd176676e1f6e2c9968237b3"
         }
     },
     "bin": [


### PR DESCRIPTION
- [Release v0.6.0 · hymkor/go-enex](https://github.com/hymkor/go-enex/releases/tag/v0.6.0)

- [Add fallback to match resources by width/height when en-media hash lookup fails by hymkor · Pull Request #9 · hymkor/go-enex](https://github.com/hymkor/go-enex/pull/9)

- [使用了Python脚本 （ enex_to_html.py ） · Issue #5 · hymkor/go-enex](https://github.com/hymkor/go-enex/issues/5)

